### PR TITLE
perf(images): responsive carousel highlights (desktop 1280 + mobile 768 url, webp q70)

### DIFF
--- a/Api/Resource/HeaderHighlightsImage.php
+++ b/Api/Resource/HeaderHighlightsImage.php
@@ -84,6 +84,9 @@ class HeaderHighlightsImage extends AbstractTranslatableResource
     public ?string $fileUrl;
 
     #[Groups([self::GROUP_READ])]
+    public ?string $fileUrlMobile = null;
+
+    #[Groups([self::GROUP_READ])]
     public ?string $originalFileUrl;
 
     #[Groups([self::GROUP_READ])]
@@ -175,6 +178,17 @@ class HeaderHighlightsImage extends AbstractTranslatableResource
     public function setFileUrl(?string $fileUrl): HeaderHighlightsImage
     {
         $this->fileUrl = $fileUrl;
+        return $this;
+    }
+
+    public function getFileUrlMobile(): ?string
+    {
+        return $this->fileUrlMobile;
+    }
+
+    public function setFileUrlMobile(?string $fileUrlMobile): HeaderHighlightsImage
+    {
+        $this->fileUrlMobile = $fileUrlMobile;
         return $this;
     }
 

--- a/Api/Serializer/HeaderHighlightsNormalizer.php
+++ b/Api/Serializer/HeaderHighlightsNormalizer.php
@@ -29,16 +29,44 @@ readonly class HeaderHighlightsNormalizer implements NormalizerInterface
         /** @var HeaderHighlightsImage $headerHighlightImage */
         $headerHighlightImage = $object;
 
+        $useTheliaLibrary = $request->get('use_thelia_library');
+        $resizeMode = $request->get('resize_mode');
+        $format = $request->get('format') ?? 'webp';
+        $quality = (int) ($request->get('quality') ?? 70);
+
+        $widthDesktop = (int) ($request->get('width') ?? 1280);
+        $widthMobile = (int) ($request->get('width_mobile') ?? 768);
+
+        // Thelia's legacy image cache keys the file name on getOptionsHash(), which
+        // is empty when height is null. A null height would make the desktop and
+        // mobile renders collide on the same cache file. Bound by a square box
+        // (height = width) so the hash differs per size while KEEP_IMAGE_RATIO stays
+        // width-driven for the landscape hero (no upscale, no borders).
+        $height = $request->get('height');
+
         [$fileUrl, $originalFileUrl] = $this->imageService->imageProcess(
             headerHighlightsImage: $headerHighlightImage->getPropelModel(),
-            useTheliaLibrary: $request->get('use_thelia_library'),
-            resizeMode: $request->get('resize_mode'),
-            width: $request->get('width') ?? 1920,
-            height: $request->get('height'),
-            format: $request->get('format') ?? 'webp',
+            useTheliaLibrary: $useTheliaLibrary,
+            resizeMode: $resizeMode,
+            width: $widthDesktop,
+            height: $height ?? $widthDesktop,
+            format: $format,
+            quality: $quality,
         );
+
+        [$fileUrlMobile] = $this->imageService->imageProcess(
+            headerHighlightsImage: $headerHighlightImage->getPropelModel(),
+            useTheliaLibrary: $useTheliaLibrary,
+            resizeMode: $resizeMode,
+            width: $widthMobile,
+            height: $height ?? $widthMobile,
+            format: $format,
+            quality: $quality,
+        );
+
         $headerHighlightImage
             ->setFileUrl($fileUrl)
+            ->setFileUrlMobile($fileUrlMobile)
             ->setOriginalFileUrl($originalFileUrl);
 
         return $this->normalizer->normalize($object, $format, $context);

--- a/Services/ImageService.php
+++ b/Services/ImageService.php
@@ -18,7 +18,7 @@ class ImageService
     }
 
 
-    public function imageProcess($headerHighlightsImage,$useTheliaLibrary,$resizeMode,$width,$height,$format): array
+    public function imageProcess($headerHighlightsImage,$useTheliaLibrary,$resizeMode,$width,$height,$format,$quality = null): array
     {
         $fileUrl = $originalFileUrl = null;
 
@@ -50,8 +50,18 @@ class ImageService
 
                 $event->setResizeMode($resize_mode);
 
+                // ImageEvent::getOptionsHash() returns '' unless width, height,
+                // resize_mode AND background_color are all set. Without it every
+                // size collides on the same cache file (-<source>.webp). Only used
+                // to fill borders (EXACT_RATIO_WITH_BORDERS), inert for KEEP_IMAGE_RATIO.
+                $event->setBackgroundColor('ffffff');
+
                 if (null !== $format) {
                     $event->setFormat($format);
+                }
+
+                if (null !== $quality) {
+                    $event->setQuality((int) $quality);
                 }
 
                 $event->setSourceFilepath($imgSourcePath)


### PR DESCRIPTION
- add fileUrlMobile to the API resource + normalizer (second render at 768px)
- lower default desktop width 1920 -> 1280, default quality 70
- set height (square bound) + background_color so getOptionsHash() is non-empty: a null height/bg made every size collide on the same legacy cache file